### PR TITLE
Fix `unknown property` error when building in CoGo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-//    id 'com.google.android.gms.oss-licenses-plugin'
 }
 
 android {
@@ -13,7 +12,7 @@ android {
         minSdk 26
         targetSdk 34
         versionCode 8
-        versionName project.versionName
+        versionName '0.8.0-alpha'
     }
 
     signingConfigs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,3 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 # android.aapt2FromMavenOverride=/data/data/com.itsaky.androidide/files/home/.androidide/aapt2
 android.enableJetifier=true
-versionName=0.8.0-alpha


### PR DESCRIPTION
When building in CoGo, the build fails with the following error :

```
FAILURE: Build failed with an exception.
* Where:
Build file '/home/ubuntu/AWS/actions-runner/_work/CodeOnTheGo/CodeOnTheGo/LayoutEditor/app/build.gradle' line: 16
* What went wrong:
A problem occurred evaluating project ':layouteditor:layouteditor-app'.
> Could not get unknown property 'versionName' for project ':layouteditor:layouteditor-app' of type org.gradle.api.Project.
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org/.
BUILD FAILED in 58s
```

This PR is intended to fix this error.