### PR TITLE
Fix/adfa-1122 xml crash

### DIFF
--- a/app/src/main/java/com/itsvks/layouteditor/activities/EditorActivity.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/activities/EditorActivity.kt
@@ -62,6 +62,7 @@ import com.itsvks.layouteditor.utils.Utils
 import com.itsvks.layouteditor.utils.doubleArgSafeLet
 import com.itsvks.layouteditor.views.CustomDrawerLayout
 import java.io.File
+import androidx.core.view.isEmpty
 
 @SuppressLint("UnsafeOptInUsageError")
 class EditorActivity : BaseActivity() {
@@ -865,7 +866,7 @@ class EditorActivity : BaseActivity() {
     }
 
     private fun saveXml() {
-        if (binding.editorLayout.childCount == 0) {
+        if (binding.editorLayout.isEmpty()) {
             project.currentLayout.saveLayout("")
             ToastUtils.showShort(getString(string.layout_saved))
             binding.editorLayout.markAsSaved()

--- a/app/src/main/java/com/itsvks/layouteditor/activities/PreviewLayoutActivity.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/activities/PreviewLayoutActivity.kt
@@ -20,7 +20,7 @@ class PreviewLayoutActivity : BaseActivity() {
         @Suppress("DEPRECATION") val layoutFile =
             intent.extras!!.getParcelable<LayoutFile>(Constants.EXTRA_KEY_LAYOUT)
         val parser = XmlLayoutParser(this)
-        parser.parseFromXml(layoutFile!!.readDesignFile(), this)
+        layoutFile?.readDesignFile()?.let { parser.parseFromXml(it, this) }
 
         val previewContainer = binding.root.findViewById<ViewGroup>(R.id.preview_container)
 
@@ -29,6 +29,6 @@ class PreviewLayoutActivity : BaseActivity() {
             LayoutParams.MATCH_PARENT
         )
 
-        previewContainer.addView(parser.root, layoutParams)
+        parser.root?.let{previewContainer.addView(it, layoutParams)}
     }
 }

--- a/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.util.AttributeSet
+import android.util.Log
 import android.view.DragEvent
 import android.view.GestureDetector
 import android.view.GestureDetector.SimpleOnGestureListener
@@ -86,7 +87,7 @@ class DesignEditor : LinearLayout {
     private var undoRedoManager: UndoRedoManager? = null
     private var isModified = false
     private lateinit var preferencesManager: PreferencesManager
-
+    private var parser: XmlLayoutParser? = null
 
     init {
         initAttributes()
@@ -107,7 +108,9 @@ class DesignEditor : LinearLayout {
     ) {
         init(context)
     }
-
+    fun getParser(): XmlLayoutParser? {
+        return parser
+    }
     private fun init(context: Context) {
         viewType = ViewType.DESIGN
         isBlueprint = false
@@ -362,13 +365,18 @@ class DesignEditor : LinearLayout {
 
     fun loadLayoutFromParser(xml: String) {
         clearAll()
-
+        // vvvvv ADD LOGGING CODE HERE vvvvv
+        Log.d("LayoutDebug", "--- LOADING LAYOUT (THIS WILL CRASH IF MALFORMED) ---")
+        Log.d("LayoutDebug", xml)
+        // ^^^^^ END OF LOGGING CODE ^^^^^
         if (xml.isEmpty()) return
 
         val parser = XmlLayoutParser(context)
+        this.parser = parser
+
         parser.parseFromXml(xml, context)
 
-        addView(parser.root)
+        parser.root?.let {  addView(it) }
         viewAttributeMap = parser.viewAttributeMap
 
         for (view in (viewAttributeMap as HashMap<View, *>?)!!.keys) {
@@ -444,6 +452,12 @@ class DesignEditor : LinearLayout {
     fun updateUndoRedoHistory() {
         if (undoRedoManager == null) return
         val result = XmlLayoutGenerator().generate(this, false)
+
+        // vvvvv ADD LOGGING CODE HERE vvvvv
+        Log.d("LayoutDebug", "--- GENERATED XML (ABOUT TO BE SAVED) ---")
+        Log.d("LayoutDebug", result)
+        // ^^^^^ END OF LOGGING CODE ^^^^^
+
         undoRedoManager!!.addToHistory(result)
         markAsModified()
     }

--- a/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
@@ -551,40 +551,54 @@ class DesignEditor : LinearLayout {
     }
 
     fun showDefinedAttributes(target: View) {
-        val keys = viewAttributeMap[target]!!.keySet()
-        val values = viewAttributeMap[target]!!.values()
-
-        val attrs: MutableList<HashMap<String, Any>> = ArrayList()
+        val allKeysAndValues = viewAttributeMap[target] ?: return
         val allAttrs = initializer.getAllAttributesForView(target)
 
-        val dialog = BottomSheetDialog(context)
-        val binding =
-            ShowAttributesDialogBinding.inflate(dialog.layoutInflater)
+        // --- START: NEW, MORE ROBUST FILTERING LOGIC ---
 
+        // Create three new lists that will be guaranteed to be in sync.
+        val displayKeys: MutableList<String> = ArrayList()
+        val displayValues: MutableList<String> = ArrayList()
+        val displayAttrs: MutableList<HashMap<String, Any>> = ArrayList()
+
+        val originalKeys = allKeysAndValues.keySet()
+        val originalValues = allKeysAndValues.values()
+
+        // Iterate through all the attributes that are currently on the view.
+        for (i in originalKeys.indices) {
+            val key = originalKeys[i]
+
+            // Find a matching definition for the key in our list of all possible attributes.
+            val foundAttrDef = allAttrs.find { it[Constants.KEY_ATTRIBUTE_NAME].toString() == key }
+
+            // ONLY if a definition is found, add the key, its value, and its definition
+            // to our display lists. This automatically filters out any key without a
+            // definition, such as "xmlns:..." and "tools:...".
+            if (foundAttrDef != null) {
+                displayKeys.add(key)
+                displayValues.add(originalValues[i])
+                displayAttrs.add(foundAttrDef)
+            }
+        }
+        // --- END: NEW FILTERING LOGIC ---
+
+        val dialog = BottomSheetDialog(context)
+        val binding = ShowAttributesDialogBinding.inflate(dialog.layoutInflater)
         dialog.setContentView(binding.root)
         TooltipCompat.setTooltipText(binding.btnAdd, "Add attribute")
         TooltipCompat.setTooltipText(binding.btnDelete, "Delete")
 
-        for (key: String in keys) {
-            for (map: HashMap<String, Any> in allAttrs) {
-                if ((map[Constants.KEY_ATTRIBUTE_NAME].toString() == key)) {
-                    attrs.add(map)
-                    break
-                }
-            }
-        }
+        // Now, we use our new, guaranteed-to-be-in-sync lists.
+        val appliedAttributesAdapter = AppliedAttributesAdapter(displayAttrs, displayValues)
 
-        val appliedAttributesAdapter = AppliedAttributesAdapter(attrs, values)
-
-        appliedAttributesAdapter.onClick = {
-            showAttributeEdit(target, keys[it])
+        appliedAttributesAdapter.onClick = { position ->
+            showAttributeEdit(target, displayKeys[position])
             dialog.dismiss()
         }
 
-        appliedAttributesAdapter.onRemoveButtonClick = {
+        appliedAttributesAdapter.onRemoveButtonClick = { position ->
             dialog.dismiss()
-
-            val view = removeAttribute(target, keys[it])
+            val view = removeAttribute(target, displayKeys[position])
             showDefinedAttributes(view)
         }
 
@@ -797,37 +811,29 @@ class DesignEditor : LinearLayout {
         @Suppress("NAME_SHADOWING")
         var target = target
         val allAttrs = initializer.getAllAttributesForView(target)
-        val currentAttr =
-            initializer.getAttributeFromKey(attributeKey, allAttrs)
-
+        val currentAttr = initializer.getAttributeFromKey(attributeKey, allAttrs)
         val attributeMap = viewAttributeMap[target]
 
-        if (currentAttr != null) {
-            if (currentAttr.containsKey(Constants.KEY_CAN_DELETE)) return target
+        if (currentAttr?.containsKey(Constants.KEY_CAN_DELETE) == true) {
+            return target
         }
 
-        val name =
-            if (attributeMap!!.contains("android:id")) attributeMap.getValue("android:id") else null
+        val name = if (attributeMap!!.contains("android:id")) attributeMap.getValue("android:id") else null
         val id = if (name != null) getViewId(name.replace("@+id/", "")) else -1
         attributeMap.removeValue(attributeKey)
 
-        if ((attributeKey == "android:id")) {
+        if (attributeKey == "android:id") {
             removeId(target, false)
             target.id = -1
             target.requestLayout()
 
-            // delete all id attributes for views
             for (view: View in viewAttributeMap.keys) {
                 val map = viewAttributeMap[view]
-
                 for (key: String in map!!.keySet()) {
                     val value = map.getValue(key)
-
-                    if (value.startsWith("@id/") && (value == name!!.replace(
-                            "+",
-                            ""
-                        ))
-                    ) map.removeValue(key)
+                    if (value.startsWith("@id/") && (value == name!!.replace("+", ""))) {
+                        map.removeValue(key)
+                    }
                 }
             }
             updateStructure()
@@ -835,36 +841,30 @@ class DesignEditor : LinearLayout {
         }
 
         viewAttributeMap.remove(target)
-
         val parent = target.parent as ViewGroup
         val indexOfView = parent.indexOfChild(target)
-
         parent.removeView(target)
 
         val childs: MutableList<View> = ArrayList()
-
         if (target is ViewGroup) {
             val group = target
-
             if (group.childCount > 0) {
                 for (i in 0 until group.childCount) {
                     childs.add(group.getChildAt(i))
                 }
             }
-
             group.removeAllViews()
         }
 
         if (name != null) removeId(target, false)
-
         target = InvokeUtil.createView(target.javaClass.name, context) as View
         rearrangeListeners(target)
 
         if (target is ViewGroup) {
-            target.setMinimumWidth(Utils.pxToDp(context, 20))
-            target.setMinimumHeight(Utils.pxToDp(context, 20))
+            target.minimumWidth = Utils.pxToDp(context, 20)
+            target.minimumHeight = Utils.pxToDp(context, 20)
             val group = target
-            if (childs.size > 0) {
+            if (childs.isNotEmpty()) {
                 for (i in childs.indices) {
                     group.addView(childs[i])
                 }
@@ -880,23 +880,21 @@ class DesignEditor : LinearLayout {
             target.requestLayout()
         }
 
-        val keys = attributeMap.keySet()
-        val values = attributeMap.values()
-        val attrs: MutableList<HashMap<String, Any>> = ArrayList()
+        val currentKeys = attributeMap.keySet()
+        val currentValues = attributeMap.values()
 
-        for (key: String in keys) {
-            for (map: HashMap<String, Any> in allAttrs) {
-                if ((map[Constants.KEY_ATTRIBUTE_NAME].toString() == key)) {
-                    attrs.add(map)
-                    break
-                }
+        for (i in currentKeys.indices) {
+            val key = currentKeys[i]
+
+            if (key == "android:id") {
+                continue
             }
-        }
 
-        for (i in keys.indices) {
-            val key = keys[i]
-            if ((key == "android:id")) continue
-            initializer.applyAttribute(target, values[i], attrs[i])
+            val attrDef = initializer.getAttributeFromKey(key, allAttrs)
+
+            if (attrDef != null) {
+                initializer.applyAttribute(target, currentValues[i], attrDef)
+            }
         }
 
         try {

--- a/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
@@ -554,9 +554,6 @@ class DesignEditor : LinearLayout {
         val allKeysAndValues = viewAttributeMap[target] ?: return
         val allAttrs = initializer.getAllAttributesForView(target)
 
-        // --- START: NEW, MORE ROBUST FILTERING LOGIC ---
-
-        // Create three new lists that will be guaranteed to be in sync.
         val displayKeys: MutableList<String> = ArrayList()
         val displayValues: MutableList<String> = ArrayList()
         val displayAttrs: MutableList<HashMap<String, Any>> = ArrayList()
@@ -564,23 +561,17 @@ class DesignEditor : LinearLayout {
         val originalKeys = allKeysAndValues.keySet()
         val originalValues = allKeysAndValues.values()
 
-        // Iterate through all the attributes that are currently on the view.
         for (i in originalKeys.indices) {
             val key = originalKeys[i]
 
-            // Find a matching definition for the key in our list of all possible attributes.
             val foundAttrDef = allAttrs.find { it[Constants.KEY_ATTRIBUTE_NAME].toString() == key }
 
-            // ONLY if a definition is found, add the key, its value, and its definition
-            // to our display lists. This automatically filters out any key without a
-            // definition, such as "xmlns:..." and "tools:...".
             if (foundAttrDef != null) {
                 displayKeys.add(key)
                 displayValues.add(originalValues[i])
                 displayAttrs.add(foundAttrDef)
             }
         }
-        // --- END: NEW FILTERING LOGIC ---
 
         val dialog = BottomSheetDialog(context)
         val binding = ShowAttributesDialogBinding.inflate(dialog.layoutInflater)

--- a/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/DesignEditor.kt
@@ -365,10 +365,6 @@ class DesignEditor : LinearLayout {
 
     fun loadLayoutFromParser(xml: String) {
         clearAll()
-        // vvvvv ADD LOGGING CODE HERE vvvvv
-        Log.d("LayoutDebug", "--- LOADING LAYOUT (THIS WILL CRASH IF MALFORMED) ---")
-        Log.d("LayoutDebug", xml)
-        // ^^^^^ END OF LOGGING CODE ^^^^^
         if (xml.isEmpty()) return
 
         val parser = XmlLayoutParser(context)
@@ -432,7 +428,7 @@ class DesignEditor : LinearLayout {
 
     private fun clearAll() {
         removeAllViews()
-        structureView!!.clear()
+        structureView?.clear()
         viewAttributeMap.clear()
     }
 
@@ -445,18 +441,13 @@ class DesignEditor : LinearLayout {
     }
 
     private fun updateStructure() {
-        if (childCount == 0) structureView!!.clear()
-        else structureView!!.setView(getChildAt(0))
+        if (childCount == 0) structureView?.clear()
+        else structureView?.setView(getChildAt(0))
     }
 
     fun updateUndoRedoHistory() {
         if (undoRedoManager == null) return
         val result = XmlLayoutGenerator().generate(this, false)
-
-        // vvvvv ADD LOGGING CODE HERE vvvvv
-        Log.d("LayoutDebug", "--- GENERATED XML (ABOUT TO BE SAVED) ---")
-        Log.d("LayoutDebug", result)
-        // ^^^^^ END OF LOGGING CODE ^^^^^
 
         undoRedoManager!!.addToHistory(result)
         markAsModified()

--- a/app/src/main/java/com/itsvks/layouteditor/editor/convert/ConvertImportedXml.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/convert/ConvertImportedXml.kt
@@ -1,62 +1,69 @@
 package com.itsvks.layouteditor.editor.convert
 
 import android.content.Context
-import com.itsvks.layouteditor.editor.DesignEditor
-import com.itsvks.layouteditor.tools.XmlLayoutGenerator
-import com.itsvks.layouteditor.tools.XmlLayoutParser
+import com.itsvks.layouteditor.utils.FileUtil
+import org.json.JSONObject
+import org.xml.sax.InputSource
 import java.io.File
+import java.io.StringReader
+import java.util.regex.Pattern
 import javax.xml.parsers.DocumentBuilderFactory
-import androidx.core.view.isEmpty
 
 class ConvertImportedXml(private val xml: String?) {
 
-  /**
-   * Converts an Android layout XML into the canonical format needed by the editor.
-   * It ensures all tags are fully qualified class names and all namespaces are preserved.
-   */
-  fun getXmlConverted(context: Context): String? {
-    if (xml.isNullOrBlank()) {
-      return null
+    fun getXmlConverted(context: Context): String? {
+        var convertedXml = xml
+
+        if (isWellFormed(xml)) {
+            val pattern = "<([a-zA-Z0-9]+\\.)*([a-zA-Z0-9]+)"
+
+            val matcher = Pattern.compile(pattern).matcher(
+                xml.toString()
+            )
+            try {
+                while (matcher.find()) {
+                    val fullTag = matcher.group(0)?.replace("<", "")
+                    val widgetName = matcher.group(2)
+
+                    val classes =
+                        JSONObject(FileUtil.readFromAsset("widgetclasses.json", context))
+
+                    val widgetClass = widgetName?.let {
+                        try {
+                            classes.getString(it)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                            // If the widget isn't found in the mapping, use the original widget name
+                            fullTag
+                        }
+                    }
+                    if (convertedXml != null) {
+                        convertedXml = convertedXml.replace("<$fullTag", "<$widgetClass")
+                    }
+                    if (convertedXml != null) {
+                        convertedXml = convertedXml.replace("</$fullTag", "</$widgetClass")
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                return null
+            }
+        } else {
+            return null
+        }
+        return convertedXml
     }
 
-    val tempEditor = DesignEditor(context)
-
-    try {
-      tempEditor.loadLayoutFromParser(xml)
-    } catch (e: Exception) {
-      e.printStackTrace()  // Null pointer exeption throwing
-      /**
-       * 0 = {StackTraceElement@41501} "com.itsvks.layouteditor.editor.DesignEditor.clearAll(DesignEditor.kt:435)"
-       * 1 = {StackTraceElement@41502} "com.itsvks.layouteditor.editor.DesignEditor.loadLayoutFromParser(DesignEditor.kt:367)"
-       * 2 = {StackTraceElement@41503} "com.itsvks.layouteditor.editor.convert.ConvertImportedXml.getXmlConverted(ConvertImportedXml.kt:25)"
-       * 3 = {StackTraceElement@41504} "com.itsvks.layouteditor.activities.EditorActivity.androidToDesignConversion(EditorActivity.kt:190)"
-       * 4 = {StackTraceElement@41505} "com.itsvks.layouteditor.activities.EditorActivity.init(EditorActivity.kt:134)"
-       * 5 = {StackTraceElement@41506} "com.itsvks.layouteditor.activities.EditorActivity.onCreate(EditorActivity.kt:103)"
-       * 6 = {StackTraceElement@41507} "android.app.Activity.performCreate(Activity.java:8616)"
-       * 7 = {StackTraceElement@41508} "android.app.Activity.performCreate(Activity.java:8594)"
-       * 8 = {StackTraceElement@41509} "android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1465)"
-       * 9 = {StackTraceElement@41510} "android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3929)"
-       * 10 = {StackTraceElement@41511} "android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4087)"
-       * 11 = {StackTraceElement@41512} "android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:114)"
-       * 12 = {StackTraceElement@41513} "android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)"
-       * 13 = {StackTraceElement@41514} "android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)"
-       * 14 = {StackTraceElement@41515} "android.app.ActivityThread$H.handleMessage(ActivityThread.java:2560)"
-       * 15 = {StackTraceElement@41516} "android.os.Handler.dispatchMessage(Handler.java:106)"
-       * 16 = {StackTraceElement@41517} "android.os.Looper.loopOnce(Looper.java:243)"
-       * 17 = {StackTraceElement@41518} "android.os.Looper.loop(Looper.java:338)"
-       * 18 = {StackTraceElement@41519} "android.app.ActivityThread.main(ActivityThread.java:8524)"
-       * 19 = {StackTraceElement@41520} "java.lang.reflect.Method.invoke(Native Method)"
-       * 20 = {StackTraceElement@41521} "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)"
-       * 21 = {StackTraceElement@41522} "com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1064)"
-       */
-      return null
+    private fun isWellFormed(xml: String?): Boolean {
+        try {
+            val factory = DocumentBuilderFactory.newInstance()
+            val builder = factory.newDocumentBuilder()
+            val source = InputSource(StringReader(xml))
+            builder.parse(source)
+            return true
+        } catch (e: Exception) {
+            return false
+        }
     }
 
-    if (tempEditor.isEmpty()) {
-      return null
-    }
-
-    val generator = XmlLayoutGenerator()
-    return generator.generate(tempEditor, false)
-  }
 }

--- a/app/src/main/java/com/itsvks/layouteditor/editor/convert/ConvertImportedXml.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/editor/convert/ConvertImportedXml.kt
@@ -1,159 +1,62 @@
 package com.itsvks.layouteditor.editor.convert
 
 import android.content.Context
-import com.itsvks.layouteditor.utils.FileUtil
-import org.json.JSONObject
-import org.xml.sax.InputSource
+import com.itsvks.layouteditor.editor.DesignEditor
+import com.itsvks.layouteditor.tools.XmlLayoutGenerator
+import com.itsvks.layouteditor.tools.XmlLayoutParser
 import java.io.File
-import java.io.StringReader
-import java.util.regex.Pattern
 import javax.xml.parsers.DocumentBuilderFactory
+import androidx.core.view.isEmpty
 
 class ConvertImportedXml(private val xml: String?) {
 
+  /**
+   * Converts an Android layout XML into the canonical format needed by the editor.
+   * It ensures all tags are fully qualified class names and all namespaces are preserved.
+   */
   fun getXmlConverted(context: Context): String? {
-    var convertedXml = xml
-
-    if (isWellFormed(xml)) {
-      val pattern = "<([a-zA-Z0-9]+\\.)*([a-zA-Z0-9]+)"
-
-      val matcher = Pattern.compile(pattern).matcher(
-        xml.toString()
-      )
-      try {
-        while (matcher.find()) {
-          val fullTag = matcher.group(0)?.replace("<", "")
-          val widgetName = matcher.group(2)
-
-          val classes =
-            JSONObject(FileUtil.readFromAsset("widgetclasses.json", context))
-
-          val widgetClass = widgetName?.let {
-            try {
-              classes.getString(it)
-            } catch (e: Exception) {
-              e.printStackTrace()
-              // If the widget isn't found in the mapping, use the original widget name
-              fullTag
-            }
-          }
-          if (convertedXml != null) {
-            convertedXml = convertedXml.replace("<$fullTag", "<$widgetClass")
-          }
-          if (convertedXml != null) {
-            convertedXml = convertedXml.replace("</$fullTag", "</$widgetClass")
-          }
-        }
-      } catch (e: Exception) {
-        e.printStackTrace()
-        return null
-      }
-    } else {
+    if (xml.isNullOrBlank()) {
       return null
     }
-    return convertedXml
-  }
 
-  private fun isWellFormed(xml: String?): Boolean {
-    try {
-      val factory = DocumentBuilderFactory.newInstance()
-      val builder = factory.newDocumentBuilder()
-      val source = InputSource(StringReader(xml))
-      builder.parse(source)
-      return true
-    } catch (e: Exception) {
-      return false
-    }
-  }
-
-  fun isLayoutFile(filePath: String): Boolean {
-    val file = File(filePath)
-    if (!file.exists() || !file.isFile) {
-      return false
-    }
-
-    val layoutTags = arrayOf(
-      "Button",
-      "ImageButton",
-      "ChipGroup",
-      "Chip",
-      "CheckBox",
-      "RadioGroup",
-      "RadioButton",
-      "ToggleButton",
-      "Switch",
-      "FloatingActionButton",
-      "Spinner",
-      "ScrollView",
-      "HorizontalScrollView",
-      "NestedScrollView",
-      "ViewPager",
-      "CardView",
-      "AppBarLayout",
-      "BottomAppBar",
-      "Toolbar",
-      "MaterialToolbar",
-      "TabItem",
-      "RelativeLayout",
-      "LinearLayout",
-      "FrameLayout",
-      "TableLayout",
-      "TableRow",
-      "Space",
-      "GridLayout",
-      "TabHost",
-      "GridView",
-      "TextView",
-      "AutoCompleteTextView",
-      "MultiAutoCompleteTextView",
-      "CheckedTextView",
-      "View",
-      "ImageView",
-      "WebView",
-      "VideoView",
-      "TextClock",
-      "ProgressBar",
-      "SeekBar",
-      "RatingBar",
-      "TextureView",
-      "SurfaceView",
-      "EditText",
-      "DatePicker",
-      "TimePicker",
-      "Chronometer",
-      "ViewFlipper",
-      "ListView",
-      "GridView",
-      "SearchView",
-      "RatingBar",
-      "NumberPicker",
-      "SeekBar",
-      "ProgressBar",
-      "QuickContactBadge",
-      "Switch",
-      "TextSwitcher",
-      "ImageSwitcher",
-      "AdapterViewFlipper",
-      "AnalogClock",
-      "DigitalClock",
-      "ConstraintLayout"
-    )
+    val tempEditor = DesignEditor(context)
 
     try {
-      val factory = DocumentBuilderFactory.newInstance()
-      val builder = factory.newDocumentBuilder()
-      val document = builder.parse(file)
-      var rootTag = document.documentElement.tagName
-      if (rootTag.contains(".")) rootTag = rootTag.substring(rootTag.lastIndexOf(".") + 1)
-
-      for (layoutTag in layoutTags) {
-        if (rootTag == layoutTag) {
-          return true
-        }
-      }
+      tempEditor.loadLayoutFromParser(xml)
     } catch (e: Exception) {
-      e.printStackTrace()
+      e.printStackTrace()  // Null pointer exeption throwing
+      /**
+       * 0 = {StackTraceElement@41501} "com.itsvks.layouteditor.editor.DesignEditor.clearAll(DesignEditor.kt:435)"
+       * 1 = {StackTraceElement@41502} "com.itsvks.layouteditor.editor.DesignEditor.loadLayoutFromParser(DesignEditor.kt:367)"
+       * 2 = {StackTraceElement@41503} "com.itsvks.layouteditor.editor.convert.ConvertImportedXml.getXmlConverted(ConvertImportedXml.kt:25)"
+       * 3 = {StackTraceElement@41504} "com.itsvks.layouteditor.activities.EditorActivity.androidToDesignConversion(EditorActivity.kt:190)"
+       * 4 = {StackTraceElement@41505} "com.itsvks.layouteditor.activities.EditorActivity.init(EditorActivity.kt:134)"
+       * 5 = {StackTraceElement@41506} "com.itsvks.layouteditor.activities.EditorActivity.onCreate(EditorActivity.kt:103)"
+       * 6 = {StackTraceElement@41507} "android.app.Activity.performCreate(Activity.java:8616)"
+       * 7 = {StackTraceElement@41508} "android.app.Activity.performCreate(Activity.java:8594)"
+       * 8 = {StackTraceElement@41509} "android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1465)"
+       * 9 = {StackTraceElement@41510} "android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3929)"
+       * 10 = {StackTraceElement@41511} "android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4087)"
+       * 11 = {StackTraceElement@41512} "android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:114)"
+       * 12 = {StackTraceElement@41513} "android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)"
+       * 13 = {StackTraceElement@41514} "android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)"
+       * 14 = {StackTraceElement@41515} "android.app.ActivityThread$H.handleMessage(ActivityThread.java:2560)"
+       * 15 = {StackTraceElement@41516} "android.os.Handler.dispatchMessage(Handler.java:106)"
+       * 16 = {StackTraceElement@41517} "android.os.Looper.loopOnce(Looper.java:243)"
+       * 17 = {StackTraceElement@41518} "android.os.Looper.loop(Looper.java:338)"
+       * 18 = {StackTraceElement@41519} "android.app.ActivityThread.main(ActivityThread.java:8524)"
+       * 19 = {StackTraceElement@41520} "java.lang.reflect.Method.invoke(Native Method)"
+       * 20 = {StackTraceElement@41521} "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)"
+       * 21 = {StackTraceElement@41522} "com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1064)"
+       */
+      return null
     }
-    return false
+
+    if (tempEditor.isEmpty()) {
+      return null
+    }
+
+    val generator = XmlLayoutGenerator()
+    return generator.generate(tempEditor, false)
   }
 }

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
@@ -53,21 +53,6 @@ public class XmlLayoutGenerator {
 
     String className = getClassName(view, indent);
 
-    /*
-    if (depth == 0) {
-      if (namespaces != null && !namespaces.isEmpty()) {
-        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
-          builder.append(TAB)
-                  .append("xmlns:")
-                  .append(entry.getKey())
-                  .append("=\"")
-                  .append(entry.getValue())
-                  .append("\"\n");
-        }
-      }
-    }
-    */
-
     List<String> keys =
             (attributeMap.get(view) != null) ? attributeMap.get(view).keySet() : new ArrayList<>();
     for (String key : keys) {

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
@@ -18,6 +18,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class XmlLayoutGenerator {
   final StringBuilder builder = new StringBuilder();
@@ -47,10 +48,13 @@ public class XmlLayoutGenerator {
 
         """);
 
-    return peek(editor.getChildAt(0), editor.getViewAttributeMap(), 0);
+    XmlLayoutParser parser = editor.getParser();
+    Map<String, String> namespaces = (parser != null) ? parser.getNamespaceDeclarations() : new HashMap<>();
+
+    return peek(editor.getChildAt(0), editor.getViewAttributeMap(), namespaces, 0);
   }
 
-  private String peek(View view, HashMap<View, AttributeMap> attributeMap, int depth) {
+  private String peek(View view, HashMap<View, AttributeMap> attributeMap, Map<String, String> namespaces, int depth) {
     if (attributeMap == null || view == null) return "";
     String indent = getIndent(depth);
     int nextDepth = depth;
@@ -58,14 +62,20 @@ public class XmlLayoutGenerator {
     String className = getClassName(view, indent);
 
     if (depth == 0) {
-      builder.append(TAB).append("xmlns:android=\"http://schemas.android.com/apk/res/android\"\n");
-      builder.append(TAB).append("xmlns:app=\"http://schemas.android.com/apk/res-auto\"\n");
+      if (namespaces != null && !namespaces.isEmpty()) {
+        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
+          builder.append(TAB)
+                  .append("xmlns:")
+                  .append(entry.getKey())
+                  .append("=\"")
+                  .append(entry.getValue())
+                  .append("\"\n");
+        }
+      }
     }
 
     List<String> keys =
-      (attributeMap.get(view) != null) ? attributeMap.get(view).keySet() : new ArrayList<>();
-    List<String> values =
-      (attributeMap.get(view) != null) ? attributeMap.get(view).values() : new ArrayList<>();
+            (attributeMap.get(view) != null) ? attributeMap.get(view).keySet() : new ArrayList<>();
     for (String key : keys) {
       // If the value contains special characters it will be converted
       builder.append(TAB).append(indent).append(key).append("=\"").append(StringEscapeUtils.escapeXml11(attributeMap.get(view).getValue(key))).append("\"\n");
@@ -86,7 +96,7 @@ public class XmlLayoutGenerator {
           builder.append(">\n\n");
 
           for (int i = 0; i < group.getChildCount(); i++) {
-            peek(group.getChildAt(i), attributeMap, nextDepth);
+            peek(group.getChildAt(i), attributeMap, namespaces, nextDepth);
           }
 
           builder.append(indent).append("</").append(className).append(">\n\n");

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
@@ -43,15 +43,9 @@ public class XmlLayoutGenerator {
 
         """);
 
-    // REMOVED: We no longer need the parser instance or a separate namespaces map.
-    // XmlLayoutParser parser = editor.getParser();
-    // Map<String, String> namespaces = (parser != null) ? parser.getNamespaceDeclarations() : new HashMap<>();
-
-    // CHANGED: The call to peek is now simpler.
     return peek(editor.getChildAt(0), editor.getViewAttributeMap(), 0);
   }
 
-  // CHANGED: The 'namespaces' map parameter is removed.
   private String peek(View view, HashMap<View, AttributeMap> attributeMap, int depth) {
     if (attributeMap == null || view == null) return "";
     String indent = getIndent(depth);
@@ -59,8 +53,6 @@ public class XmlLayoutGenerator {
 
     String className = getClassName(view, indent);
 
-    // REMOVED: This special block for namespaces is no longer needed.
-    // The main attribute loop will handle them automatically.
     /*
     if (depth == 0) {
       if (namespaces != null && !namespaces.isEmpty()) {
@@ -76,8 +68,6 @@ public class XmlLayoutGenerator {
     }
     */
 
-    // This loop now writes ALL attributes for the view. For the root view,
-    // this will include xmlns:android, android:layout_width, etc.
     List<String> keys =
             (attributeMap.get(view) != null) ? attributeMap.get(view).keySet() : new ArrayList<>();
     for (String key : keys) {

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
@@ -89,7 +89,6 @@ public class XmlLayoutGenerator {
           builder.append(">\n\n");
 
           for (int i = 0; i < group.getChildCount(); i++) {
-            // CHANGED: The recursive call is also simplified.
             peek(group.getChildAt(i), attributeMap, nextDepth);
           }
 

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutGenerator.java
@@ -4,17 +4,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CalendarView;
 import android.widget.SearchView;
-
 import androidx.annotation.NonNull;
-
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.tabs.TabLayout;
 import com.itsvks.layouteditor.editor.DesignEditor;
 import com.itsvks.layouteditor.editor.initializer.AttributeMap;
-
 import org.apache.commons.text.StringEscapeUtils;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -23,7 +19,6 @@ import java.util.Map;
 public class XmlLayoutGenerator {
   final StringBuilder builder = new StringBuilder();
   String TAB = "\t";
-
   boolean useSuperclasses;
 
   public String generate(@NonNull DesignEditor editor, boolean useSuperclasses) {
@@ -48,19 +43,25 @@ public class XmlLayoutGenerator {
 
         """);
 
-    XmlLayoutParser parser = editor.getParser();
-    Map<String, String> namespaces = (parser != null) ? parser.getNamespaceDeclarations() : new HashMap<>();
+    // REMOVED: We no longer need the parser instance or a separate namespaces map.
+    // XmlLayoutParser parser = editor.getParser();
+    // Map<String, String> namespaces = (parser != null) ? parser.getNamespaceDeclarations() : new HashMap<>();
 
-    return peek(editor.getChildAt(0), editor.getViewAttributeMap(), namespaces, 0);
+    // CHANGED: The call to peek is now simpler.
+    return peek(editor.getChildAt(0), editor.getViewAttributeMap(), 0);
   }
 
-  private String peek(View view, HashMap<View, AttributeMap> attributeMap, Map<String, String> namespaces, int depth) {
+  // CHANGED: The 'namespaces' map parameter is removed.
+  private String peek(View view, HashMap<View, AttributeMap> attributeMap, int depth) {
     if (attributeMap == null || view == null) return "";
     String indent = getIndent(depth);
     int nextDepth = depth;
 
     String className = getClassName(view, indent);
 
+    // REMOVED: This special block for namespaces is no longer needed.
+    // The main attribute loop will handle them automatically.
+    /*
     if (depth == 0) {
       if (namespaces != null && !namespaces.isEmpty()) {
         for (Map.Entry<String, String> entry : namespaces.entrySet()) {
@@ -73,11 +74,13 @@ public class XmlLayoutGenerator {
         }
       }
     }
+    */
 
+    // This loop now writes ALL attributes for the view. For the root view,
+    // this will include xmlns:android, android:layout_width, etc.
     List<String> keys =
             (attributeMap.get(view) != null) ? attributeMap.get(view).keySet() : new ArrayList<>();
     for (String key : keys) {
-      // If the value contains special characters it will be converted
       builder.append(TAB).append(indent).append(key).append("=\"").append(StringEscapeUtils.escapeXml11(attributeMap.get(view).getValue(key))).append("\"\n");
     }
 
@@ -86,17 +89,18 @@ public class XmlLayoutGenerator {
     if (view instanceof ViewGroup) {
       ViewGroup group = (ViewGroup) view;
       if (!(group instanceof CalendarView)
-        && !(group instanceof SearchView)
-        && !(group instanceof NavigationView)
-        && !(group instanceof BottomNavigationView)
-        && !(group instanceof TabLayout)) {
+              && !(group instanceof SearchView)
+              && !(group instanceof NavigationView)
+              && !(group instanceof BottomNavigationView)
+              && !(group instanceof TabLayout)) {
         nextDepth++;
 
         if (group.getChildCount() > 0) {
           builder.append(">\n\n");
 
           for (int i = 0; i < group.getChildCount(); i++) {
-            peek(group.getChildAt(i), attributeMap, namespaces, nextDepth);
+            // CHANGED: The recursive call is also simplified.
+            peek(group.getChildAt(i), attributeMap, nextDepth);
           }
 
           builder.append(indent).append("</").append(className).append(">\n\n");
@@ -116,7 +120,7 @@ public class XmlLayoutGenerator {
   @NonNull
   private String getClassName(View view, String indent) {
     String className =
-      useSuperclasses ? view.getClass().getSuperclass().getName() : view.getClass().getName();
+            useSuperclasses ? view.getClass().getSuperclass().getName() : view.getClass().getName();
 
     if (useSuperclasses) {
       if (className.startsWith("android.widget.")) {

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -143,6 +143,28 @@ class XmlLayoutParser(context: Context) {
                     view?.let { viewAttributeMap[it] = map }
                 }
 
+                /**
+                 * This method is responsible for:
+                 * 1) Finding ViewGroups.(that's why we are looking for end tag)
+                 * 2) Adding view to ViewGroup as a child.(viewGroup.addView)
+                 * 3) Removing the view that was added to it's parent from the list. As it is now stored in the parent,
+                 * and we do not need it in the list anymore.
+                 * END_TAG event is triggered when we reach the end of each ViewGroup. Top to bottom. Root ViewGroup is
+                 * triggered last.
+                 *
+                 * * Min XML depth for this scenario is 2. File = 0 -> ViewGroup = 1 -> View = 2
+                 *
+                 * Therefore we are not interested in anything with depth < 2.
+                 *
+                 * Let's assume depth is 3. File -> LinearLayout -> ConstraintLayout -> View
+                 * depth - 2 = 1. This will bring us to the correct parent.
+                 * depth - 1 = 1. This will bring us to correct child.
+                 *
+                 * After adding View to ConstraintLayout, View is removed from the listViews and is considered finished.
+                 * This process will repeat until all Views and ViewGroups will be added to corresponding parents and list
+                 * view will become empty.
+                 */
+
                 XmlPullParser.END_TAG -> {
                     val depth = parser.depth
                     if (depth >= 2 && listViews.size >= 2) {

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -153,22 +153,34 @@ class XmlLayoutParser(context: Context) {
                         }
                     }
 
-                    val map = AttributeMap()
+                    // --- 1. CORRECTLY CAPTURE NAMESPACES ---
+                    // We get the namespaces declared specifically on this tag.
+                    val currentDepth = parser.depth
+                    val prevDepthCount = if (currentDepth > 1) parser.getNamespaceCount(currentDepth - 1) else 0
+                    val currentDepthCount = parser.getNamespaceCount(currentDepth)
 
+                    for (i in prevDepthCount until currentDepthCount) {
+                        val prefix = parser.getNamespacePrefix(i)
+                        val uri = parser.getNamespaceUri(i)
+                        // We only need to store declarations that have a prefix (e.g., android, app, tools).
+                        if (prefix != null) {
+                            namespaceDeclarations[prefix] = uri
+                        }
+                    }
+
+                    // --- 2. PARSE REGULAR ATTRIBUTES ---
+                    // This loop now only processes non-namespace attributes.
+                    val map = AttributeMap()
                     for (i in 0 until parser.attributeCount) {
                         val prefix = parser.getAttributePrefix(i)
                         val name = parser.getAttributeName(i)
 
-                        if ("xmlns" == prefix) {
-                            namespaceDeclarations[name] = parser.getAttributeValue(i)
+                        val fullName = if (prefix != null && prefix.isNotEmpty()) {
+                            "$prefix:$name"
                         } else {
-                            val fullName = if (prefix != null && prefix.isNotEmpty()) {
-                                "$prefix:$name"
-                            } else {
-                                name
-                            }
-                            map.putValue(fullName, parser.getAttributeValue(i))
+                            name
                         }
+                        map.putValue(fullName, parser.getAttributeValue(i))
                     }
 
                     view?.let { viewAttributeMap[it] = map }

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -24,6 +24,7 @@ import java.io.StringReader
 class XmlLayoutParser(context: Context) {
 
     val viewAttributeMap: HashMap<View, AttributeMap> = HashMap()
+    val namespaceDeclarations: MutableMap<String, String> = mutableMapOf()
 
     private val initializer: AttributeInitializer
     private val listViews: MutableList<View> = ArrayList()
@@ -45,9 +46,9 @@ class XmlLayoutParser(context: Context) {
         initializer = AttributeInitializer(context, attributes, parentAttributes)
     }
 
-    val root: View
+    val root: View?
         get() {
-            return listViews[0]
+            return listViews.getOrNull(0)
         }
 
     fun parseFromXml(xml: String, context: Context) {
@@ -81,6 +82,15 @@ class XmlLayoutParser(context: Context) {
         while (parser.eventType != XmlPullParser.END_DOCUMENT) {
             when (parser.eventType) {
                 XmlPullParser.START_TAG -> {
+
+                    // vvvvv ADD LOGGING CODE HERE vvvvv
+                    if (parser.depth == 1) { // Log attributes only for the root element
+                        Log.d("LayoutDebug", "--- PARSING ROOT ELEMENT ATTRIBUTES ---")
+                        for (i in 0 until parser.attributeCount) {
+                            Log.d("LayoutDebug", "FOUND ATTRIBUTE: name='${parser.getAttributeName(i)}', value='${parser.getAttributeValue(i)}'")
+                        }
+                    }
+
                     val tagName = parser.name
 
                     // Skip NavigationView to avoid invalid parent crash
@@ -146,9 +156,18 @@ class XmlLayoutParser(context: Context) {
                     val map = AttributeMap()
 
                     for (i in 0 until parser.attributeCount) {
+                        val prefix = parser.getAttributePrefix(i)
                         val name = parser.getAttributeName(i)
-                        if (!name.startsWith("xmlns")) {
-                            map.putValue(name, parser.getAttributeValue(i))
+
+                        if ("xmlns" == prefix) {
+                            namespaceDeclarations[name] = parser.getAttributeValue(i)
+                        } else {
+                            val fullName = if (prefix != null && prefix.isNotEmpty()) {
+                                "$prefix:$name"
+                            } else {
+                                name
+                            }
+                            map.putValue(fullName, parser.getAttributeValue(i))
                         }
                     }
 
@@ -180,8 +199,8 @@ class XmlLayoutParser(context: Context) {
                 XmlPullParser.END_TAG -> {
                     val depth = parser.depth
                     if (depth >= 2 && listViews.size >= 2) {
-                        val parent = listViews[depth - 2]
-                        val child = listViews[depth - 1]
+                        val parent = listViews.getOrNull(depth - 2) ?: return
+                        val child = listViews.getOrNull(depth - 1) ?: return
                         if (parent is ViewGroup) {
                             parent.addView(child)
                             listViews.removeAt(depth - 1)

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -46,7 +46,6 @@ class XmlLayoutParser(context: Context) {
         get() = listViews.getOrNull(0)
 
     fun parseFromXml(xml: String, context: Context) {
-        // Clear previous state for a fresh parse
         listViews.clear()
         viewAttributeMap.clear()
         clear()
@@ -63,7 +62,6 @@ class XmlLayoutParser(context: Context) {
             e.printStackTrace()
         }
 
-        // Apply attributes after the entire view hierarchy is built
         for ((view, map) in viewAttributeMap) {
             if (map.contains("android:id")) {
                 addNewId(view, map.getValue("android:id"))

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -23,8 +23,8 @@ import java.io.StringReader
 
 class XmlLayoutParser(context: Context) {
 
+    // IMPORTANT: We no longer need a separate namespaceDeclarations map.
     val viewAttributeMap: HashMap<View, AttributeMap> = HashMap()
-    val namespaceDeclarations: MutableMap<String, String> = mutableMapOf()
 
     private val initializer: AttributeInitializer
     private val listViews: MutableList<View> = ArrayList()
@@ -33,64 +33,51 @@ class XmlLayoutParser(context: Context) {
         val attributes = Gson()
             .fromJson<HashMap<String, List<HashMap<String, Any>>>>(
                 FileUtil.readFromAsset(Constants.ATTRIBUTES_FILE, context),
-                object : TypeToken<HashMap<String, List<HashMap<String, Any>>>>() {
-                }.type
+                object : TypeToken<HashMap<String, List<HashMap<String, Any>>>>() {}.type
             )
         val parentAttributes = Gson()
             .fromJson<HashMap<String, List<HashMap<String, Any>>>>(
                 FileUtil.readFromAsset(Constants.PARENT_ATTRIBUTES_FILE, context),
-                object : TypeToken<HashMap<String, List<HashMap<String, Any>>>>() {
-                }.type
+                object : TypeToken<HashMap<String, List<HashMap<String, Any>>>>() {}.type
             )
-
         initializer = AttributeInitializer(context, attributes, parentAttributes)
     }
 
     val root: View?
-        get() {
-            return listViews.getOrNull(0)
-        }
+        get() = listViews.getOrNull(0)
 
     fun parseFromXml(xml: String, context: Context) {
+        // Clear previous state for a fresh parse
+        listViews.clear()
+        viewAttributeMap.clear()
+        clear()
+
         try {
             val factory = XmlPullParserFactory.newInstance()
             val parser = factory.newPullParser()
-            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+            // We turn this OFF. We will handle prefixes manually, which is more reliable.
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
             parser.setInput(StringReader(xml))
-
             parseFromXml(parser, context)
-
         } catch (e: XmlPullParserException) {
             e.printStackTrace()
         } catch (e: IOException) {
             e.printStackTrace()
         }
 
-        clear()
-
-        for (view in viewAttributeMap.keys) {
-            val map = viewAttributeMap[view]!!
-            if ("android:id" in map.keySet()) {
+        // Apply attributes after the entire view hierarchy is built
+        for ((view, map) in viewAttributeMap) {
+            if (map.contains("android:id")) {
                 addNewId(view, map.getValue("android:id"))
             }
             applyAttributes(view, map)
         }
-
     }
 
     private fun parseFromXml(parser: XmlPullParser, context: Context) {
         while (parser.eventType != XmlPullParser.END_DOCUMENT) {
             when (parser.eventType) {
                 XmlPullParser.START_TAG -> {
-
-                    // vvvvv ADD LOGGING CODE HERE vvvvv
-                    if (parser.depth == 1) { // Log attributes only for the root element
-                        Log.d("LayoutDebug", "--- PARSING ROOT ELEMENT ATTRIBUTES ---")
-                        for (i in 0 until parser.attributeCount) {
-                            Log.d("LayoutDebug", "FOUND ATTRIBUTE: name='${parser.getAttributeName(i)}', value='${parser.getAttributeValue(i)}'")
-                        }
-                    }
-
                     val tagName = parser.name
 
                     // Skip NavigationView to avoid invalid parent crash
@@ -104,7 +91,6 @@ class XmlLayoutParser(context: Context) {
                     }
 
                     var view: View? = null
-
                     when (tagName) {
                         "fragment" -> {
                             view = FrameLayout(context).apply {
@@ -153,61 +139,16 @@ class XmlLayoutParser(context: Context) {
                         }
                     }
 
-                    // --- 1. CORRECTLY CAPTURE NAMESPACES ---
-                    // We get the namespaces declared specifically on this tag.
-                    val currentDepth = parser.depth
-                    val prevDepthCount = if (currentDepth > 1) parser.getNamespaceCount(currentDepth - 1) else 0
-                    val currentDepthCount = parser.getNamespaceCount(currentDepth)
-
-                    for (i in prevDepthCount until currentDepthCount) {
-                        val prefix = parser.getNamespacePrefix(i)
-                        val uri = parser.getNamespaceUri(i)
-                        // We only need to store declarations that have a prefix (e.g., android, app, tools).
-                        if (prefix != null) {
-                            namespaceDeclarations[prefix] = uri
-                        }
-                    }
-
-                    // --- 2. PARSE REGULAR ATTRIBUTES ---
-                    // This loop now only processes non-namespace attributes.
+                    // --- SIMPLIFIED AND CORRECTED ATTRIBUTE PARSING ---
                     val map = AttributeMap()
                     for (i in 0 until parser.attributeCount) {
-                        val prefix = parser.getAttributePrefix(i)
-                        val name = parser.getAttributeName(i)
-
-                        val fullName = if (prefix != null && prefix.isNotEmpty()) {
-                            "$prefix:$name"
-                        } else {
-                            name
-                        }
-                        map.putValue(fullName, parser.getAttributeValue(i))
+                        // With namespaces off, getAttributeName() returns the full prefixed name.
+                        val fullName = parser.getAttributeName(i)
+                        val value = parser.getAttributeValue(i)
+                        map.putValue(fullName, value)
                     }
-
                     view?.let { viewAttributeMap[it] = map }
                 }
-
-                /**
-                 * This method is responsible for:
-                 * 1) Finding ViewGroups.(that's why we are looking for end tag)
-                 * 2) Adding view to ViewGroup as a child.(viewGroup.addView)
-                 * 3) Removing the view that was added to it's parent from the list. As it is now stored in the parent,
-                 * and we do not need it in the list anymore.
-                 * END_TAG event is triggered when we reach the end of each ViewGroup. Top to bottom. Root ViewGroup is
-                 * triggered last.
-                 *
-                 * * Min XML depth for this scenario is 2. File = 0 -> ViewGroup = 1 -> View = 2
-                 *
-                 * Therefore we are not interested in anything with depth < 2.
-                 *
-                 * Let's assume depth is 3. File -> LinearLayout -> ConstraintLayout -> View
-                 * depth - 2 = 1. This will bring us to the correct parent.
-                 * depth - 1 = 1. This will bring us to correct child.
-                 *
-                 * After adding View to ConstraintLayout, View is removed from the listViews and is considered finished.
-                 * This process will repeat until all Views and ViewGroups will be added to corresponding parents and list
-                 * view will become empty.
-                 */
-
                 XmlPullParser.END_TAG -> {
                     val depth = parser.depth
                     if (depth >= 2 && listViews.size >= 2) {

--- a/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
+++ b/app/src/main/java/com/itsvks/layouteditor/tools/XmlLayoutParser.kt
@@ -23,7 +23,6 @@ import java.io.StringReader
 
 class XmlLayoutParser(context: Context) {
 
-    // IMPORTANT: We no longer need a separate namespaceDeclarations map.
     val viewAttributeMap: HashMap<View, AttributeMap> = HashMap()
 
     private val initializer: AttributeInitializer
@@ -55,7 +54,6 @@ class XmlLayoutParser(context: Context) {
         try {
             val factory = XmlPullParserFactory.newInstance()
             val parser = factory.newPullParser()
-            // We turn this OFF. We will handle prefixes manually, which is more reliable.
             parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
             parser.setInput(StringReader(xml))
             parseFromXml(parser, context)
@@ -130,25 +128,23 @@ class XmlLayoutParser(context: Context) {
 
                         else -> {
                             val result = createView(tagName, context)
-                            if (result is Exception) {
-                                throw result
-                            } else {
+                            if (result is Exception) throw result
+                            else {
                                 view = result as? View
                                 view?.let { listViews.add(it) }
                             }
                         }
                     }
 
-                    // --- SIMPLIFIED AND CORRECTED ATTRIBUTE PARSING ---
                     val map = AttributeMap()
                     for (i in 0 until parser.attributeCount) {
-                        // With namespaces off, getAttributeName() returns the full prefixed name.
                         val fullName = parser.getAttributeName(i)
                         val value = parser.getAttributeValue(i)
                         map.putValue(fullName, value)
                     }
                     view?.let { viewAttributeMap[it] = map }
                 }
+
                 XmlPullParser.END_TAG -> {
                     val depth = parser.depth
                     if (depth >= 2 && listViews.size >= 2) {


### PR DESCRIPTION
### Summary

This pull request resolves a cascade of critical crashes and stability issues within the Layout Editor, fundamentally improving its reliability. The core of the problem was improper handling of XML namespaces and attributes without definitions, which caused errors during file import, saving, and attribute management.

These changes make the entire workflow—importing external layouts, editing attributes, saving, and reloading—robust and resilient, preventing data corruption and ensuring a stable user experience.

### Crashes Solved and Why the Fixes are Important

This PR addresses the following distinct bugs that were discovered and fixed in sequence:

* **1. Crash on Reload (`Undefined Prefix: tools`)**
    * **Problem:** The app would crash when reopening a layout that had been edited and saved.
    * **Root Cause:** The `XmlLayoutParser` was discarding XML namespace declarations (like `xmlns:tools`), but the `XmlLayoutGenerator` would still write attributes that used those namespaces (like `tools:context`). This created a malformed XML file that the parser would crash on during the next load.
    * **Importance:** This was a critical data-loss bug that made the save/reload cycle completely unreliable. The fix ensures all namespace data is preserved, guaranteeing that saved files can be safely reopened.

* **2. Crash on Removing Attributes (`IndexOutOfBoundsException`)**
    * **Problem:** The app crashed when the user clicked the "remove" button for an attribute in the editor UI.
    * **Root Cause:** Attributes present in the layout file (like `xmlns:*` and `tools:*`) did not have corresponding definitions in `attributes.json`. The code that built parallel lists for the UI (`keys`, `values`, `attrs`) would skip these undefined attributes in the `attrs` list but not the others. This caused the lists to have different sizes, leading to the crash when accessing an index.
    * **Importance:** This bug made the attribute editor UI unstable and unusable for real-world layout files. The fix robustly filters the attribute list to only show and process attributes with known definitions, making the UI stable and preventing the crash.

* **3. Crash on App Startup (`EIO: I/O error`)**
    * **Problem:** A low-level file system error would crash the app on startup while trying to read the `OpenedFilesCache`.
    * **Root Cause:** The `getOpenedFilesCache` method was performing a write-style operation (`file.createNewFile()`) right before a read operation. This is an incorrect file handling practice that can leave the file system in an inconsistent state, leading to the low-level I/O error on some devices.
    * **Importance:** This was a critical stability issue that could prevent the editor from starting at all. The fix separates the file preparation logic for reading and writing, adhering to proper file I/O practices.

* **4. Crash on Initial Import (`NullPointerException`)**
    * **Problem:** The app crashed when trying to import an existing Android layout file for the first time.
    * **Root Cause:** The import process created a temporary "headless" instance of `DesignEditor` whose UI components (like `structureView`) were not initialized. A method within the editor (`clearAll()`) used an unsafe call (`!!`) on this null property, causing the crash.
    * **Importance:** This bug made the entire "Import XML" feature unusable. The fix (using a safe call `?.`) makes the `DesignEditor` component more robust and allows it to be used safely in non-UI contexts like the import converter.